### PR TITLE
fix conversion of sql.NullByte

### DIFF
--- a/table.go
+++ b/table.go
@@ -200,8 +200,8 @@ func newColumn(f reflect.StructField) (*column, error) {
 			col.typ = "TINYINT"
 			col.size = 1
 		case nullByteType:
-			col.typ = "VARBINARY"
-			col.size = 767
+			col.typ = "TINYINT"
+			col.unsigned = true
 		case nullFloat64Type:
 			col.typ = "DOUBLE"
 		case nullInt16Type:

--- a/table_test.go
+++ b/table_test.go
@@ -87,7 +87,7 @@ func TestTable(t *testing.T) {
 			{name: "null_time", rawName: "NullTime", typ: "DATETIME"},
 			{name: "null_string", rawName: "NullString", typ: "VARCHAR", size: 191},
 			{name: "null_bool", rawName: "NullBool", typ: "TINYINT", size: 1},
-			{name: "null_byte", rawName: "NullByte", typ: "VARBINARY", size: 767},
+			{name: "null_byte", rawName: "NullByte", typ: "TINYINT", unsigned: true},
 			{name: "null_float64", rawName: "NullFloat64", typ: "DOUBLE"},
 			{name: "null_int16", rawName: "NullInt16", typ: "SMALLINT"},
 			{name: "null_int32", rawName: "NullInt32", typ: "INTEGER"},


### PR DESCRIPTION
The result of `sql.NullByte` should be same as the result of `uint8`.