### PR TITLE
Fix base branch to main

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,7 +3,7 @@ name: Go
 on:
   push:
   pull_request:
-    branches: [master]
+    branches: [ "main" ]
 
 env:
   MYSQL_TEST_USER: gotest


### PR DESCRIPTION
Currently, the base branch for launching Go workflow is "master". However, there is no "master" branch in this repository. I believe the "main" branch is the correct one.

I fixed it.