### PR TITLE
support  decimal type with precision and scale

### DIFF
--- a/table.go
+++ b/table.go
@@ -264,6 +264,16 @@ func newColumn(f reflect.StructField) (*column, error) {
 				}
 				col.srid = int(v)
 			case "type":
+				if (strings.HasPrefix(val, "DECIMAL")) && !strings.HasSuffix(val, ")") {
+					var comb string
+					comb, remain, _ = strings.Cut(remain, ",")
+					val = val + "," + comb
+				}
+				if strings.HasPrefix(val, "NUMERIC") && !strings.HasSuffix(val, ")") {
+					var comb string
+					comb, remain, _ = strings.Cut(remain, ",")
+					val = val + "," + comb
+				}
 				col.typ = val
 				col.unsigned = false
 				col.size = 0

--- a/table.go
+++ b/table.go
@@ -264,12 +264,12 @@ func newColumn(f reflect.StructField) (*column, error) {
 				}
 				col.srid = int(v)
 			case "type":
-				if strings.HasPrefix(val, "DECIMAL") && !strings.HasSuffix(val, ")") {
+				if strings.HasPrefix(val, "DECIMAL(") && !strings.HasSuffix(val, ")") {
 					var comb string
 					comb, remain, _ = strings.Cut(remain, ",")
 					val = val + "," + comb
 				}
-				if strings.HasPrefix(val, "NUMERIC") && !strings.HasSuffix(val, ")") {
+				if strings.HasPrefix(val, "NUMERIC(") && !strings.HasSuffix(val, ")") {
 					var comb string
 					comb, remain, _ = strings.Cut(remain, ",")
 					val = val + "," + comb

--- a/table.go
+++ b/table.go
@@ -264,7 +264,7 @@ func newColumn(f reflect.StructField) (*column, error) {
 				}
 				col.srid = int(v)
 			case "type":
-				if (strings.HasPrefix(val, "DECIMAL")) && !strings.HasSuffix(val, ")") {
+				if strings.HasPrefix(val, "DECIMAL") && !strings.HasSuffix(val, ")") {
 					var comb string
 					comb, remain, _ = strings.Cut(remain, ",")
 					val = val + "," + comb

--- a/table_test.go
+++ b/table_test.go
@@ -34,10 +34,12 @@ type FooBar struct {
 	// custom type
 	MyInt      myInt
 	CustomType customType `ddl:",type=TIMESTAMP"`
+	Decimal    float64    `ddl:",type=DECIMAL"`
+	Numeric    float64    `ddl:",type=NUMERIC"`
 
 	// cutom type that contains comma
-	Decimal float64 `ddl:",type=DECIMAL(9,6)"`
-	Numeric float64 `ddl:",type=NUMERIC(9,6)"`
+	DecimalWithExactPrecision float64 `ddl:",type=DECIMAL(9,6)"`
+	NumericWithExactPrecision float64 `ddl:",type=NUMERIC(9,6)"`
 
 	// pointers
 	PInt8  *int8
@@ -85,8 +87,10 @@ func TestTable(t *testing.T) {
 			{name: "json_value", rawName: "JSONValue", typ: "JSON"},
 			{name: "my_int", rawName: "MyInt", typ: "BIGINT"},
 			{name: "custom_type", rawName: "CustomType", typ: "TIMESTAMP"},
-			{name: "decimal", rawName: "Decimal", typ: "DECIMAL(9,6)"},
-			{name: "numeric", rawName: "Numeric", typ: "NUMERIC(9,6)"},
+			{name: "decimal", rawName: "Decimal", typ: "DECIMAL"},
+			{name: "numeric", rawName: "Numeric", typ: "NUMERIC"},
+			{name: "decimal_with_exact_precision", rawName: "DecimalWithExactPrecision", typ: "DECIMAL(9,6)"},
+			{name: "numeric_with_exact_precision", rawName: "NumericWithExactPrecision", typ: "NUMERIC(9,6)"},
 			{name: "p_int8", rawName: "PInt8", typ: "TINYINT"},
 			{name: "p_p_int8", rawName: "PPInt8", typ: "TINYINT"},
 			{name: "fuga", rawName: "Hoge", typ: "INTEGER"},

--- a/table_test.go
+++ b/table_test.go
@@ -34,8 +34,10 @@ type FooBar struct {
 	// custom type
 	MyInt      myInt
 	CustomType customType `ddl:",type=TIMESTAMP"`
-	Decimal    float64    `ddl:",type=DECIMAL(9,6)"`
-	Numeric    float64    `ddl:",type=NUMERIC(9,6)"`
+
+	// cutom type that contains comma
+	Decimal float64 `ddl:",type=DECIMAL(9,6)"`
+	Numeric float64 `ddl:",type=NUMERIC(9,6)"`
 
 	// pointers
 	PInt8  *int8

--- a/table_test.go
+++ b/table_test.go
@@ -34,6 +34,8 @@ type FooBar struct {
 	// custom type
 	MyInt      myInt
 	CustomType customType `ddl:",type=TIMESTAMP"`
+	Decimal    float64    `ddl:",type=DECIMAL(9,6)"`
+	Numeric    float64    `ddl:",type=NUMERIC(9,6)"`
 
 	// pointers
 	PInt8  *int8
@@ -81,6 +83,8 @@ func TestTable(t *testing.T) {
 			{name: "json_value", rawName: "JSONValue", typ: "JSON"},
 			{name: "my_int", rawName: "MyInt", typ: "BIGINT"},
 			{name: "custom_type", rawName: "CustomType", typ: "TIMESTAMP"},
+			{name: "decimal", rawName: "Decimal", typ: "DECIMAL(9,6)"},
+			{name: "numeric", rawName: "Numeric", typ: "NUMERIC(9,6)"},
 			{name: "p_int8", rawName: "PInt8", typ: "TINYINT"},
 			{name: "p_p_int8", rawName: "PPInt8", typ: "TINYINT"},
 			{name: "fuga", rawName: "Hoge", typ: "INTEGER"},


### PR DESCRIPTION

When parse a struct tag, extract value by separating with comma.
I want to use DECIMAL type with specified precision and scale like `type=DECIMAL(9,6)`, but this is parsed as `DECIMAL(9`.

if parsing `type` and its type is `DECIMAL` or `NUMERIC` , the next value is read.
