### PR TITLE
fix syntax of referencial actions

### DIFF
--- a/maker.go
+++ b/maker.go
@@ -286,13 +286,13 @@ func (m *Maker) generateIndex(w io.Writer, table *table) {
 		io.WriteString(w, " (")
 		io.WriteString(w, strings.Join(quoteAll(idx.references), ", "))
 		io.WriteString(w, ")")
-		if idx.onUpdate != "" {
-			io.WriteString(w, " ON UPDATE ")
-			io.WriteString(w, string(idx.onUpdate))
-		}
 		if idx.onDelete != "" {
 			io.WriteString(w, " ON DELETE ")
 			io.WriteString(w, string(idx.onDelete))
+		}
+		if idx.onUpdate != "" {
+			io.WriteString(w, " ON UPDATE ")
+			io.WriteString(w, string(idx.onUpdate))
 		}
 		io.WriteString(w, ",\n")
 	}

--- a/maker_test.go
+++ b/maker_test.go
@@ -462,7 +462,7 @@ func TestMaker_Generate(t *testing.T) {
 		"CREATE TABLE `foo5` (\n"+
 		"    `id` INTEGER NOT NULL,\n"+
 		"    `name` VARCHAR(191) NOT NULL,\n"+
-		"    CONSTRAINT `fk_foo1` FOREIGN KEY (`id`) REFERENCES `foo1` (`id`) ON UPDATE CASCADE ON DELETE CASCADE,\n"+
+		"    CONSTRAINT `fk_foo1` FOREIGN KEY (`id`) REFERENCES `foo1` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,\n"+
 		"    PRIMARY KEY (`id`)\n"+
 		") ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;\n\n\n"+
 		"DROP TABLE IF EXISTS `foo1`;\n\n"+


### PR DESCRIPTION
According to the reference, foreign key referential actions are defined in the order "ON DELETE" "ON UPDATE" .
However, in the codebase, the order is "ON UPDATE" "ON DELETE" . It induces a syntax error, so I fixed it.

```
[CONSTRAINT [symbol]] FOREIGN KEY
    [index_name] (col_name, ...)
    REFERENCES tbl_name (col_name,...)
    [ON DELETE reference_option]
    [ON UPDATE reference_option]

reference_option:
    RESTRICT | CASCADE | SET NULL | NO ACTION | SET DEFAULT
```
ref. https://dev.mysql.com/doc/refman/8.0/en/create-table-foreign-keys.html



