### PR TITLE
Support nullable unsigned integer foreign key

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ schema.UpdateUser(context.TODO(), db, &schema.User{
 |       `null`        |        `NULL` (default: `NOT NULL`)         |
 |       `auto`        |              `AUTO INCREMENT`               |
 |     `invisible`     |                 `INVISIBLE`                 |
+|     `unsigned`      |                  `UNSIGNED`                 |
 |    `size=<size>`    | `VARCHAR(<size>)`, `DATETIME(<size>)`, etc. |
 |    `type=<type>`    |             override field type             |
 |    `srid=<srid>`    |                override SRID                |

--- a/maker_test.go
+++ b/maker_test.go
@@ -318,6 +318,15 @@ func (*Foo20) PrimaryKey() *PrimaryKey {
 	return NewPrimaryKey("id")
 }
 
+type Foo21 struct {
+	ID       int32
+	ParentID nullUint32 `ddl:",type=INTEGER,unsigned,null"`
+}
+
+func (*Foo21) PrimaryKey() *PrimaryKey {
+	return NewPrimaryKey("id")
+}
+
 type Fkp1 struct {
 	ID string
 }
@@ -840,6 +849,16 @@ func TestMaker_Generate(t *testing.T) {
 		"CREATE TABLE `foo20` (\n"+
 		"    `id` INTEGER NOT NULL AUTO_INCREMENT,\n"+
 		"    `json` JSON NOT NULL,\n"+
+		"    PRIMARY KEY (`id`)\n"+
+		") ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;\n\n"+
+		"SET foreign_key_checks=1;\n")
+
+	// unsigned integer specified in struct tag
+	testMaker(t, []any{&Foo21{}}, "SET foreign_key_checks=0;\n\n"+
+		"DROP TABLE IF EXISTS `foo21`;\n\n"+
+		"CREATE TABLE `foo21` (\n"+
+		"    `id` INTEGER NOT NULL,\n"+
+		"    `parent_id` INTEGER UNSIGNED NULL,\n"+
 		"    PRIMARY KEY (`id`)\n"+
 		") ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;\n\n"+
 		"SET foreign_key_checks=1;\n")

--- a/maker_test.go
+++ b/maker_test.go
@@ -573,13 +573,9 @@ func (*Fkp8) PrimaryKey() *PrimaryKey {
 	return NewPrimaryKey("id")
 }
 
-type NullUint32 struct {
-	Uint32 uint32
-	Valid  bool
-}
 type Fkc8 struct {
 	ID       string
-	ParentID NullUint32 `ddl:",type=INTEGER UNSIGNED,null"`
+	ParentID nullUint32 `ddl:",type=INTEGER,unsigned,null"`
 }
 
 func (*Fkc8) PrimaryKey() *PrimaryKey {
@@ -979,33 +975,18 @@ func TestMaker_Generate(t *testing.T) {
 	testMaker(t, []any{&Fkp8{}, &Fkc8{}}, "SET foreign_key_checks=0;\n\n"+
 		"DROP TABLE IF EXISTS `fkp8`;\n\n"+
 		"CREATE TABLE `fkp8` (\n"+
-		"    `id` INTERGER UNSIGNED NOT NULL,\n"+
+		"    `id` INTEGER UNSIGNED NOT NULL,\n"+
 		"    PRIMARY KEY (`id`)\n"+
 		") ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;\n\n\n"+
 		"DROP TABLE IF EXISTS `fkc8`;\n\n"+
 		"CREATE TABLE `fkc8` (\n"+
 		"    `id` VARCHAR(191) NOT NULL,\n"+
-		"    `parent_id` INTERGER UNSIGNED NULL,\n"+
+		"    `parent_id` INTEGER UNSIGNED NULL,\n"+
 		"    INDEX `idx_parent_id` (`parent_id`),\n"+
 		"    CONSTRAINT `fk_fkc8_parent_id` FOREIGN KEY (`parent_id`) REFERENCES `fkp8` (`id`),\n"+
 		"    PRIMARY KEY (`id`)\n"+
 		") ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;\n\n"+
 		"SET foreign_key_checks=1;\n")
-
-	// testMaker(t, []any{&Fkp2{}, &Fkc2{}}, "SET foreign_key_checks=0;\n\n"+
-	// 	"DROP TABLE IF EXISTS `fkp2`;\n\n"+
-	// 	"CREATE TABLE `fkp2` (\n"+
-	// 	"    `id` INTEGER UNSIGNED NOT NULL,\n"+
-	// 	"    PRIMARY KEY (`id`)\n"+
-	// 	") ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;\n\n\n"+
-	// 	"DROP TABLE IF EXISTS `fkc1`;\n\n"+
-	// 	"CREATE TABLE `fkc1` (\n"+
-	// 	"    `id` VARCHAR(191) NOT NULL,\n"+
-	// 	"    `parent_id` VARCHAR(191) NULL,\n"+
-	// 	"    CONSTRAINT `fk_fkc2_parent_id` FOREIGN KEY (`id`) REFERENCES `fkp2` (`id`),\n"+
-	// 	"    PRIMARY KEY (`id`)\n"+
-	// 	") ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;\n\n"+
-	// 	"SET foreign_key_checks=1;\n")
 
 	testMakerError(t, []any{&Foo11{}, &Foo12{}}, []string{
 		`duplicated name of table: "foo11"`,

--- a/maker_test.go
+++ b/maker_test.go
@@ -859,7 +859,7 @@ func TestMaker_Generate(t *testing.T) {
 		") ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;\n\n"+
 		"SET foreign_key_checks=1;\n")
 
-	// NULL foreign key
+	// nullble string foreign key
 	testMaker(t, []any{&Fkp1{}, &Fkc1{}}, "SET foreign_key_checks=0;\n\n"+
 		"DROP TABLE IF EXISTS `fkp1`;\n\n"+
 		"CREATE TABLE `fkp1` (\n"+
@@ -876,6 +876,7 @@ func TestMaker_Generate(t *testing.T) {
 		") ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;\n\n"+
 		"SET foreign_key_checks=1;\n")
 
+	// nullable bigint foreign key
 	testMaker(t, []any{&Fkp2{}, &Fkc2{}}, "SET foreign_key_checks=0;\n\n"+
 		"DROP TABLE IF EXISTS `fkp2`;\n\n"+
 		"CREATE TABLE `fkp2` (\n"+
@@ -892,6 +893,7 @@ func TestMaker_Generate(t *testing.T) {
 		") ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;\n\n"+
 		"SET foreign_key_checks=1;\n")
 
+	// nullable integer foreign key
 	testMaker(t, []any{&Fkp3{}, &Fkc3{}}, "SET foreign_key_checks=0;\n\n"+
 		"DROP TABLE IF EXISTS `fkp3`;\n\n"+
 		"CREATE TABLE `fkp3` (\n"+
@@ -908,6 +910,7 @@ func TestMaker_Generate(t *testing.T) {
 		") ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;\n\n"+
 		"SET foreign_key_checks=1;\n")
 
+	// nullable smallint foreign key
 	testMaker(t, []any{&Fkp4{}, &Fkc4{}}, "SET foreign_key_checks=0;\n\n"+
 		"DROP TABLE IF EXISTS `fkp4`;\n\n"+
 		"CREATE TABLE `fkp4` (\n"+
@@ -924,6 +927,7 @@ func TestMaker_Generate(t *testing.T) {
 		") ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;\n\n"+
 		"SET foreign_key_checks=1;\n")
 
+	// nullable tinyint foreign key
 	testMaker(t, []any{&Fkp5{}, &Fkc5{}}, "SET foreign_key_checks=0;\n\n"+
 		"DROP TABLE IF EXISTS `fkp5`;\n\n"+
 		"CREATE TABLE `fkp5` (\n"+
@@ -940,6 +944,7 @@ func TestMaker_Generate(t *testing.T) {
 		") ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;\n\n"+
 		"SET foreign_key_checks=1;\n")
 
+	// nullable double foreign key
 	testMaker(t, []any{&Fkp6{}, &Fkc6{}}, "SET foreign_key_checks=0;\n\n"+
 		"DROP TABLE IF EXISTS `fkp6`;\n\n"+
 		"CREATE TABLE `fkp6` (\n"+
@@ -956,6 +961,7 @@ func TestMaker_Generate(t *testing.T) {
 		") ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;\n\n"+
 		"SET foreign_key_checks=1;\n")
 
+	// nullable tinyint(1) foreign key
 	testMaker(t, []any{&Fkp7{}, &Fkc7{}}, "SET foreign_key_checks=0;\n\n"+
 		"DROP TABLE IF EXISTS `fkp7`;\n\n"+
 		"CREATE TABLE `fkp7` (\n"+
@@ -972,6 +978,7 @@ func TestMaker_Generate(t *testing.T) {
 		") ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;\n\n"+
 		"SET foreign_key_checks=1;\n")
 
+	// nullable unsigned integer foreign key
 	testMaker(t, []any{&Fkp8{}, &Fkc8{}}, "SET foreign_key_checks=0;\n\n"+
 		"DROP TABLE IF EXISTS `fkp8`;\n\n"+
 		"CREATE TABLE `fkp8` (\n"+

--- a/maker_test.go
+++ b/maker_test.go
@@ -386,6 +386,214 @@ func (*Fkc2) ForeignKeys() []*ForeignKey {
 	}
 }
 
+type Fkp3 struct {
+	ID int32
+}
+
+func (*Fkp3) PrimaryKey() *PrimaryKey {
+	return NewPrimaryKey("id")
+}
+
+type Fkc3 struct {
+	ID       string
+	ParentID sql.NullInt32 `ddl:",null"`
+}
+
+func (*Fkc3) PrimaryKey() *PrimaryKey {
+	return NewPrimaryKey("id")
+}
+
+func (*Fkc3) Indexes() []*Index {
+	return []*Index{
+		NewIndex("idx_parent_id", "parent_id"),
+	}
+}
+
+func (*Fkc3) ForeignKeys() []*ForeignKey {
+	return []*ForeignKey{
+		NewForeignKey(
+			"fk_fkc3_parent_id",
+			[]string{"parent_id"},
+			"fkp3",
+			[]string{"id"},
+		),
+	}
+}
+
+type Fkp4 struct {
+	ID int16
+}
+
+func (*Fkp4) PrimaryKey() *PrimaryKey {
+	return NewPrimaryKey("id")
+}
+
+type Fkc4 struct {
+	ID       string
+	ParentID sql.NullInt16 `ddl:",null"`
+}
+
+func (*Fkc4) PrimaryKey() *PrimaryKey {
+	return NewPrimaryKey("id")
+}
+
+func (*Fkc4) Indexes() []*Index {
+	return []*Index{
+		NewIndex("idx_parent_id", "parent_id"),
+	}
+}
+
+func (*Fkc4) ForeignKeys() []*ForeignKey {
+	return []*ForeignKey{
+		NewForeignKey(
+			"fk_fkc4_parent_id",
+			[]string{"parent_id"},
+			"fkp4",
+			[]string{"id"},
+		),
+	}
+}
+
+type Fkp5 struct {
+	ID byte
+}
+
+func (*Fkp5) PrimaryKey() *PrimaryKey {
+	return NewPrimaryKey("id")
+}
+
+type Fkc5 struct {
+	ID       string
+	ParentID sql.NullByte `ddl:",null"`
+}
+
+func (*Fkc5) PrimaryKey() *PrimaryKey {
+	return NewPrimaryKey("id")
+}
+
+func (*Fkc5) Indexes() []*Index {
+	return []*Index{
+		NewIndex("idx_parent_id", "parent_id"),
+	}
+}
+
+func (*Fkc5) ForeignKeys() []*ForeignKey {
+	return []*ForeignKey{
+		NewForeignKey(
+			"fk_fkc5_parent_id",
+			[]string{"parent_id"},
+			"fkp5",
+			[]string{"id"},
+		),
+	}
+}
+
+type Fkp6 struct {
+	ID float64
+}
+
+func (*Fkp6) PrimaryKey() *PrimaryKey {
+	return NewPrimaryKey("id")
+}
+
+type Fkc6 struct {
+	ID       string
+	ParentID sql.NullFloat64 `ddl:",null"`
+}
+
+func (*Fkc6) PrimaryKey() *PrimaryKey {
+	return NewPrimaryKey("id")
+}
+
+func (*Fkc6) Indexes() []*Index {
+	return []*Index{
+		NewIndex("idx_parent_id", "parent_id"),
+	}
+}
+
+func (*Fkc6) ForeignKeys() []*ForeignKey {
+	return []*ForeignKey{
+		NewForeignKey(
+			"fk_fkc6_parent_id",
+			[]string{"parent_id"},
+			"fkp6",
+			[]string{"id"},
+		),
+	}
+}
+
+type Fkp7 struct {
+	ID bool
+}
+
+func (*Fkp7) PrimaryKey() *PrimaryKey {
+	return NewPrimaryKey("id")
+}
+
+type Fkc7 struct {
+	ID       string
+	ParentID sql.NullBool `ddl:",null"`
+}
+
+func (*Fkc7) PrimaryKey() *PrimaryKey {
+	return NewPrimaryKey("id")
+}
+
+func (*Fkc7) Indexes() []*Index {
+	return []*Index{
+		NewIndex("idx_parent_id", "parent_id"),
+	}
+}
+
+func (*Fkc7) ForeignKeys() []*ForeignKey {
+	return []*ForeignKey{
+		NewForeignKey(
+			"fk_fkc7_parent_id",
+			[]string{"parent_id"},
+			"fkp7",
+			[]string{"id"},
+		),
+	}
+}
+
+type Fkp8 struct {
+	ID uint32
+}
+
+func (*Fkp8) PrimaryKey() *PrimaryKey {
+	return NewPrimaryKey("id")
+}
+
+type NullUint32 struct {
+	Uint32 uint32
+	Valid  bool
+}
+type Fkc8 struct {
+	ID       string
+	ParentID NullUint32 `ddl:",type=INTEGER UNSIGNED,null"`
+}
+
+func (*Fkc8) PrimaryKey() *PrimaryKey {
+	return NewPrimaryKey("id")
+}
+
+func (*Fkc8) Indexes() []*Index {
+	return []*Index{
+		NewIndex("idx_parent_id", "parent_id"),
+	}
+}
+
+func (*Fkc8) ForeignKeys() []*ForeignKey {
+	return []*ForeignKey{
+		NewForeignKey(
+			"fk_fkc8_parent_id",
+			[]string{"parent_id"},
+			"fkp8",
+			[]string{"id"},
+		),
+	}
+}
+
 func testMaker(t *testing.T, structs []any, ddl string) {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -668,6 +876,118 @@ func TestMaker_Generate(t *testing.T) {
 		"    PRIMARY KEY (`id`)\n"+
 		") ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;\n\n"+
 		"SET foreign_key_checks=1;\n")
+
+	testMaker(t, []any{&Fkp3{}, &Fkc3{}}, "SET foreign_key_checks=0;\n\n"+
+		"DROP TABLE IF EXISTS `fkp3`;\n\n"+
+		"CREATE TABLE `fkp3` (\n"+
+		"    `id` INTEGER NOT NULL,\n"+
+		"    PRIMARY KEY (`id`)\n"+
+		") ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;\n\n\n"+
+		"DROP TABLE IF EXISTS `fkc3`;\n\n"+
+		"CREATE TABLE `fkc3` (\n"+
+		"    `id` VARCHAR(191) NOT NULL,\n"+
+		"    `parent_id` INTEGER NULL,\n"+
+		"    INDEX `idx_parent_id` (`parent_id`),\n"+
+		"    CONSTRAINT `fk_fkc3_parent_id` FOREIGN KEY (`parent_id`) REFERENCES `fkp3` (`id`),\n"+
+		"    PRIMARY KEY (`id`)\n"+
+		") ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;\n\n"+
+		"SET foreign_key_checks=1;\n")
+
+	testMaker(t, []any{&Fkp4{}, &Fkc4{}}, "SET foreign_key_checks=0;\n\n"+
+		"DROP TABLE IF EXISTS `fkp4`;\n\n"+
+		"CREATE TABLE `fkp4` (\n"+
+		"    `id` SMALLINT NOT NULL,\n"+
+		"    PRIMARY KEY (`id`)\n"+
+		") ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;\n\n\n"+
+		"DROP TABLE IF EXISTS `fkc4`;\n\n"+
+		"CREATE TABLE `fkc4` (\n"+
+		"    `id` VARCHAR(191) NOT NULL,\n"+
+		"    `parent_id` SMALLINT NULL,\n"+
+		"    INDEX `idx_parent_id` (`parent_id`),\n"+
+		"    CONSTRAINT `fk_fkc4_parent_id` FOREIGN KEY (`parent_id`) REFERENCES `fkp4` (`id`),\n"+
+		"    PRIMARY KEY (`id`)\n"+
+		") ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;\n\n"+
+		"SET foreign_key_checks=1;\n")
+
+	testMaker(t, []any{&Fkp5{}, &Fkc5{}}, "SET foreign_key_checks=0;\n\n"+
+		"DROP TABLE IF EXISTS `fkp5`;\n\n"+
+		"CREATE TABLE `fkp5` (\n"+
+		"    `id` TINYINT UNSIGNED NOT NULL,\n"+
+		"    PRIMARY KEY (`id`)\n"+
+		") ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;\n\n\n"+
+		"DROP TABLE IF EXISTS `fkc5`;\n\n"+
+		"CREATE TABLE `fkc5` (\n"+
+		"    `id` VARCHAR(191) NOT NULL,\n"+
+		"    `parent_id` TINYINT UNSIGNED NULL,\n"+
+		"    INDEX `idx_parent_id` (`parent_id`),\n"+
+		"    CONSTRAINT `fk_fkc5_parent_id` FOREIGN KEY (`parent_id`) REFERENCES `fkp5` (`id`),\n"+
+		"    PRIMARY KEY (`id`)\n"+
+		") ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;\n\n"+
+		"SET foreign_key_checks=1;\n")
+
+	testMaker(t, []any{&Fkp6{}, &Fkc6{}}, "SET foreign_key_checks=0;\n\n"+
+		"DROP TABLE IF EXISTS `fkp6`;\n\n"+
+		"CREATE TABLE `fkp6` (\n"+
+		"    `id` DOUBLE NOT NULL,\n"+
+		"    PRIMARY KEY (`id`)\n"+
+		") ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;\n\n\n"+
+		"DROP TABLE IF EXISTS `fkc6`;\n\n"+
+		"CREATE TABLE `fkc6` (\n"+
+		"    `id` VARCHAR(191) NOT NULL,\n"+
+		"    `parent_id` DOUBLE NULL,\n"+
+		"    INDEX `idx_parent_id` (`parent_id`),\n"+
+		"    CONSTRAINT `fk_fkc6_parent_id` FOREIGN KEY (`parent_id`) REFERENCES `fkp6` (`id`),\n"+
+		"    PRIMARY KEY (`id`)\n"+
+		") ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;\n\n"+
+		"SET foreign_key_checks=1;\n")
+
+	testMaker(t, []any{&Fkp7{}, &Fkc7{}}, "SET foreign_key_checks=0;\n\n"+
+		"DROP TABLE IF EXISTS `fkp7`;\n\n"+
+		"CREATE TABLE `fkp7` (\n"+
+		"    `id` TINYINT(1) NOT NULL,\n"+
+		"    PRIMARY KEY (`id`)\n"+
+		") ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;\n\n\n"+
+		"DROP TABLE IF EXISTS `fkc7`;\n\n"+
+		"CREATE TABLE `fkc7` (\n"+
+		"    `id` VARCHAR(191) NOT NULL,\n"+
+		"    `parent_id` TINYINT(1) NULL,\n"+
+		"    INDEX `idx_parent_id` (`parent_id`),\n"+
+		"    CONSTRAINT `fk_fkc7_parent_id` FOREIGN KEY (`parent_id`) REFERENCES `fkp7` (`id`),\n"+
+		"    PRIMARY KEY (`id`)\n"+
+		") ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;\n\n"+
+		"SET foreign_key_checks=1;\n")
+
+	testMaker(t, []any{&Fkp8{}, &Fkc8{}}, "SET foreign_key_checks=0;\n\n"+
+		"DROP TABLE IF EXISTS `fkp8`;\n\n"+
+		"CREATE TABLE `fkp8` (\n"+
+		"    `id` INTERGER UNSIGNED NOT NULL,\n"+
+		"    PRIMARY KEY (`id`)\n"+
+		") ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;\n\n\n"+
+		"DROP TABLE IF EXISTS `fkc8`;\n\n"+
+		"CREATE TABLE `fkc8` (\n"+
+		"    `id` VARCHAR(191) NOT NULL,\n"+
+		"    `parent_id` INTERGER UNSIGNED NULL,\n"+
+		"    INDEX `idx_parent_id` (`parent_id`),\n"+
+		"    CONSTRAINT `fk_fkc8_parent_id` FOREIGN KEY (`parent_id`) REFERENCES `fkp8` (`id`),\n"+
+		"    PRIMARY KEY (`id`)\n"+
+		") ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;\n\n"+
+		"SET foreign_key_checks=1;\n")
+
+	// testMaker(t, []any{&Fkp2{}, &Fkc2{}}, "SET foreign_key_checks=0;\n\n"+
+	// 	"DROP TABLE IF EXISTS `fkp2`;\n\n"+
+	// 	"CREATE TABLE `fkp2` (\n"+
+	// 	"    `id` INTEGER UNSIGNED NOT NULL,\n"+
+	// 	"    PRIMARY KEY (`id`)\n"+
+	// 	") ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;\n\n\n"+
+	// 	"DROP TABLE IF EXISTS `fkc1`;\n\n"+
+	// 	"CREATE TABLE `fkc1` (\n"+
+	// 	"    `id` VARCHAR(191) NOT NULL,\n"+
+	// 	"    `parent_id` VARCHAR(191) NULL,\n"+
+	// 	"    CONSTRAINT `fk_fkc2_parent_id` FOREIGN KEY (`id`) REFERENCES `fkp2` (`id`),\n"+
+	// 	"    PRIMARY KEY (`id`)\n"+
+	// 	") ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;\n\n"+
+	// 	"SET foreign_key_checks=1;\n")
+
 	testMakerError(t, []any{&Foo11{}, &Foo12{}}, []string{
 		`duplicated name of table: "foo11"`,
 	})

--- a/table.go
+++ b/table.go
@@ -258,6 +258,8 @@ func newColumn(f reflect.StructField) (*column, error) {
 			col.autoIncr = true
 		case "invisible":
 			col.invisible = true
+		case "unsigned":
+			col.unsigned = true
 		default:
 			name, val, _ := strings.Cut(opt, "=")
 			switch name {

--- a/table_test.go
+++ b/table_test.go
@@ -12,6 +12,10 @@ import (
 
 type myInt int64
 type customType struct{}
+type nullUint32 struct {
+	u32   uint32
+	valid bool
+}
 
 type FooBar struct {
 	// primitive types
@@ -42,6 +46,9 @@ type FooBar struct {
 	NumericWithPrecisionAndScale float64 `ddl:",type=NUMERIC(9,6)"`
 	DecimalWithPrecision         float64 `ddl:",type=DECIMAL(9)"`
 	NumericWithPrecision         float64 `ddl:",type=NUMERIC(9)"`
+
+	// custom type that is unsigned integer
+	NullUint32 nullUint32 `ddl:",type=INTEGER,unsigned,null"`
 
 	// pointers
 	PInt8  *int8
@@ -95,6 +102,7 @@ func TestTable(t *testing.T) {
 			{name: "numeric_with_precision_and_scale", rawName: "NumericWithPrecisionAndScale", typ: "NUMERIC(9,6)"},
 			{name: "decimal_with_precision", rawName: "DecimalWithPrecision", typ: "DECIMAL(9)"},
 			{name: "numeric_with_precision", rawName: "NumericWithPrecision", typ: "NUMERIC(9)"},
+			{name: "null_uint32", rawName: "NullUint32", typ: "INTEGER", unsigned: true, null: true},
 			{name: "p_int8", rawName: "PInt8", typ: "TINYINT"},
 			{name: "p_p_int8", rawName: "PPInt8", typ: "TINYINT"},
 			{name: "fuga", rawName: "Hoge", typ: "INTEGER"},

--- a/validator.go
+++ b/validator.go
@@ -230,7 +230,7 @@ func (v *validator) validateFKRef(table *table, fk *ForeignKey) {
 			// just ignore it
 			continue
 		}
-		if refcol.typ != mycol.typ || refcol.unsigned != mycol.unsigned || refcol.rawType != mycol.rawType {
+		if refcol.typ != mycol.typ || refcol.unsigned != mycol.unsigned {
 			v.SaveErrorf("table %q, foreign key %q: column %q and referenced column %q.%q type mismatch", table.name, fk.name, mycol.name, ref.name, col)
 		}
 		if refcol.charset != mycol.charset {


### PR DESCRIPTION

## Want to do

I want to add foreign key those type is  `integer unsigned null`.

The following data is assumed.

```go
type Foo struct {
    ID uint32
}

type nullUint32 struct{
    Uint32 uint32
    Valid bool
}

type Bar struct {
    ID uint32
    FooID nullUint32 `ddl:",type=INTEGER UNSIGNED,null"`
}

func (*Foo) ForeignKeys() []*ForeignKey {
	return []*ForeignKey{
		NewForeignKey(
			"fk_bar_foo_id",
			[]string{"foo_id"},
			"foo",
			[]string{"id"},
		),
	}
}
```

## Problem

However when generating MySQL DDL, it fails to create foreign key.
The reason is that the typ and unsigned flag and rawType are different at the following code.

https://github.com/shogo82148/myddlmaker/blob/7f8e569d0fe782e27eaed60eaac7fdba009e4598/validator.go#L233


Bar.FooID type is parsed to

* typ=INTEGER UNSIGNED
* unsigned=false
* rawType=nullUint32

but referenced Foo.ID is parsed to

* typ=INTEGER
* unsigned=true
* rawType=uint32


## Solution

First, type and sign should be same, but there is no way to set unsigned flag to be true in struct tag option.So just add unsigned flag to struct tag option.

I expect Bar struct is like below.

```go
type Bar struct {
    ID uint32
    FooID nullUint32 `ddl:",type=INTEGER,unsigned,null"`
}
```

Next about rawType comparison.
Foreign keys restrict that corresponding integer columns should have same size and sign, but they may not be required to be the same Go's rawType. Therefore I've just removed this comparison.

> Corresponding columns in the foreign key and the referenced key must have similar data types. The size and sign of fixed precision types such as INTEGER and DECIMAL must be the same. 

https://dev.mysql.com/doc/refman/8.0/en/create-table-foreign-keys.html


