### PR TITLE
Add go1.22 to github actions test metrics

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,6 +22,7 @@ jobs:
           - "macos-latest"
           - "windows-latest"
         go:
+          - "1.22"
           - "1.21"
           - "1.20"
           - "1.19"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Chores**
	- Updated the Go version used in GitHub workflows to `1.22`.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->