### PR TITLE
support database/sql.Null

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,24 +197,25 @@ schema.UpdateUser(context.TODO(), db, &schema.User{
 
 ## MySQL Types and Go Types
 
-|         Golang Type          |    MySQL Column     |
-| :--------------------------: | :-----------------: |
-|            `int8`            |      `TINYINT`      |
-|           `int16`            |     `SMALLINT`      |
-|           `int32`            |      `INTEGER`      |
-|   `int64`, `sql.NullInt64`   |      `BIGINT`       |
-|   `uint8`, `sql.NullByte`    | `TINYINT UNSIGNED`  |
-|           `uint16`           | `SMALLINT UNSIGNED` |
-|           `uint32`           | `INTEGER UNSIGNED`  |
-|           `uint64`           |  `BIGINT UNSIGNED`  |
-|          `float32`           |       `FLOAT`       |
-| `float64`, `sql.NullFloat64` |      `DOUBLE`       |
-|  `string`, `sql.NullString`  |      `VARCHAR`      |
-|    `bool`, `sql.NullBool`    |    `TINYINT(1)`     |
-|           `[]byte`           |     `VARBINARY`     |
-|          `[N]byte`           |     `BINARY(N)`     |
-| `time.Time`, `sql.NullTime`  |    `DATETIME(6)`    |
-|      `json.RawMessage`       |       `JSON`        |
+|         Golang Type          |         MySQL Column          |
+| :--------------------------: | :---------------------------: |
+|            `int8`            |           `TINYINT`           |
+|           `int16`            |          `SMALLINT`           |
+|           `int32`            |           `INTEGER`           |
+|   `int64`, `sql.NullInt64`   |           `BIGINT`            |
+|   `uint8`, `sql.NullByte`    |      `TINYINT UNSIGNED`       |
+|           `uint16`           |      `SMALLINT UNSIGNED`      |
+|           `uint32`           |      `INTEGER UNSIGNED`       |
+|           `uint64`           |       `BIGINT UNSIGNED`       |
+|          `float32`           |            `FLOAT`            |
+| `float64`, `sql.NullFloat64` |           `DOUBLE`            |
+|  `string`, `sql.NullString`  |           `VARCHAR`           |
+|    `bool`, `sql.NullBool`    |         `TINYINT(1)`          |
+|           `[]byte`           |          `VARBINARY`          |
+|          `[N]byte`           |          `BINARY(N)`          |
+| `time.Time`, `sql.NullTime`  |         `DATETIME(6)`         |
+|      `json.RawMessage`       |            `JSON`             |
+|        `sql.Null[T]`         | Corresponding MySQL type to T |
 
 ## Go Struct Tag Options
 

--- a/maker_go122_test.go
+++ b/maker_go122_test.go
@@ -1,0 +1,29 @@
+//go:build go1.22
+// +build go1.22
+
+package myddlmaker
+
+import (
+	"database/sql"
+	"testing"
+)
+
+type Foo24 struct {
+	ID     int32 `ddl:",auto"`
+	Number sql.Null[uint32]
+}
+
+func (*Foo24) PrimaryKey() *PrimaryKey {
+	return NewPrimaryKey("id")
+}
+
+func TestMaker_Null(t *testing.T) {
+	testMaker(t, []any{&Foo24{}}, "SET foreign_key_checks=0;\n\n"+
+		"DROP TABLE IF EXISTS `foo24`;\n\n"+
+		"CREATE TABLE `foo24` (\n"+
+		"    `id` INTEGER NOT NULL AUTO_INCREMENT,\n"+
+		"    `number` INTEGER UNSIGNED NOT NULL,\n"+
+		"    PRIMARY KEY (`id`)\n"+
+		") ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;\n\n"+
+		"SET foreign_key_checks=1;\n")
+}


### PR DESCRIPTION
From Go 1.22, [Null](https://pkg.go.dev/database/sql#Null) type is available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Tests**
	- Added a test for database table creation functionality.
- **Refactor**
	- Improved logic handling for type cases in database operations.
	- Removed specific type check for JSON in database column definitions.
- **New Features**
	- Introduced a method to check for SQL null types in database interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->