### PR TITLE
[Feat] Support Descending Indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,8 +276,8 @@ func (*User) Indexes() []*myddlmaker.Index {
         // INDEX `idx_name` (`name`) INVISIBLE
         myddlmaker.NewIndex("idx_name", "name").Invisible(),
 
-		// INDEX `idx_name`(`id1` ASC, `id2` DESC)
-		myddlmaker.NewIndex("idx_name", "name").ASC("id1").DESC("id2"),
+		// INDEX `idx`(`id1` ASC, `id2` DESC)
+		myddlmaker.NewIndex("idx", "id1", "id2").ASC("id1").DESC("id2"),
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -275,6 +275,9 @@ func (*User) Indexes() []*myddlmaker.Index {
 
         // INDEX `idx_name` (`name`) INVISIBLE
         myddlmaker.NewIndex("idx_name", "name").Invisible(),
+
+		// INDEX `idx_name`(`id1` ASC, `id2` DESC)
+		myddlmaker.NewIndex("idx_name", "name").ASC("id1").DESC("id2"),
     }
 }
 ```

--- a/index.go
+++ b/index.go
@@ -62,7 +62,7 @@ func (idx *Index) Invisible() *Index {
 
 // ASC returns a copy of idx with the ASC option.
 // If you set both ASC and DESC, the last one will be used.
-// If you specify the non-existent column, it will be ignored.
+// If you specify the non-existent column, panic will be raised.
 func (idx *Index) ASC(column string) *Index {
 	tmp := *idx // shallow copy
 	for k, v := range idx.order {
@@ -77,7 +77,7 @@ func (idx *Index) ASC(column string) *Index {
 
 // DESC returns a copy of idx with the DESC option.
 // If you set both ASC and DESC, the last one will be used.
-// If you specify the non-existent column, it will be ignored.
+// If you specify the non-existent column, panic will be raised.
 func (idx *Index) DESC(column string) *Index {
 	tmp := *idx // shallow copy
 	for k, v := range idx.order {

--- a/index.go
+++ b/index.go
@@ -65,8 +65,11 @@ func (idx *Index) Invisible() *Index {
 // If you specify the non-existent column, it will be ignored.
 func (idx *Index) ASC(column string) *Index {
 	tmp := *idx // shallow copy
+	for k, v := range idx.order {
+		tmp.order[k] = v
+	}
 	if !containsColumn(idx, column) {
-		return &tmp
+		panic("column is missing")
 	}
 	tmp.order[column] = "ASC"
 	return &tmp
@@ -77,8 +80,11 @@ func (idx *Index) ASC(column string) *Index {
 // If you specify the non-existent column, it will be ignored.
 func (idx *Index) DESC(column string) *Index {
 	tmp := *idx // shallow copy
+	for k, v := range idx.order {
+		tmp.order[k] = v
+	}
 	if !containsColumn(idx, column) {
-		return &tmp
+		panic("column is missing")
 	}
 	tmp.order[column] = "DESC"
 	return &tmp

--- a/index.go
+++ b/index.go
@@ -26,6 +26,7 @@ type Index struct {
 	columns   []string
 	comment   string
 	invisible bool
+	order     map[string]string // key: column, value: ASC or DESC
 }
 
 // NewIndex returns a new index.
@@ -36,9 +37,12 @@ func NewIndex(name string, col ...string) *Index {
 	if len(col) == 0 {
 		panic("col is missing")
 	}
+	order := make(map[string]string, len(col))
+
 	return &Index{
 		name:    name,
 		columns: col,
+		order:   order,
 	}
 }
 
@@ -54,6 +58,41 @@ func (idx *Index) Invisible() *Index {
 	tmp := *idx // shallow copy
 	tmp.invisible = true
 	return &tmp
+}
+
+// ASC returns a copy of idx with the ASC option.
+// If you set both ASC and DESC, the last one will be used.
+// If you specify the non-existent column, it will be ignored.
+func (idx *Index) ASC(column string) *Index {
+	tmp := *idx // shallow copy
+	if !containsColumn(idx, column) {
+		return &tmp
+	}
+	tmp.order[column] = "ASC"
+	return &tmp
+}
+
+// DESC returns a copy of idx with the DESC option.
+// If you set both ASC and DESC, the last one will be used.
+// If you specify the non-existent column, it will be ignored.
+func (idx *Index) DESC(column string) *Index {
+	tmp := *idx // shallow copy
+	if !containsColumn(idx, column) {
+		return &tmp
+	}
+	tmp.order[column] = "DESC"
+	return &tmp
+}
+
+// containsColumn returns true if the index contains the column.
+// slices.Contains is supported in Go 1.21. So, we can't use it.
+func containsColumn(idx *Index, column string) bool {
+	for _, c := range idx.columns {
+		if c == column {
+			return true
+		}
+	}
+	return false
 }
 
 // UniqueIndex is a unique index of a table.

--- a/index.go
+++ b/index.go
@@ -65,6 +65,7 @@ func (idx *Index) Invisible() *Index {
 // If you specify the non-existent column, panic will be raised.
 func (idx *Index) ASC(column string) *Index {
 	tmp := *idx // shallow copy
+	tmp.order = make(map[string]string, len(tmp.columns))
 	for k, v := range idx.order {
 		tmp.order[k] = v
 	}
@@ -80,6 +81,7 @@ func (idx *Index) ASC(column string) *Index {
 // If you specify the non-existent column, panic will be raised.
 func (idx *Index) DESC(column string) *Index {
 	tmp := *idx // shallow copy
+	tmp.order = make(map[string]string, len(tmp.columns))
 	for k, v := range idx.order {
 		tmp.order[k] = v
 	}

--- a/maker.go
+++ b/maker.go
@@ -218,7 +218,16 @@ func (m *Maker) generateIndex(w io.Writer, table *table) {
 		io.WriteString(w, "    INDEX ")
 		io.WriteString(w, quote(idx.name))
 		io.WriteString(w, " (")
-		io.WriteString(w, strings.Join(quoteAll(idx.columns), ", "))
+		// Add the column name and the order.
+		columnWithOrder := make([]string, 0, len(idx.columns))
+		for _, column := range idx.columns {
+			if order, ok := idx.order[column]; ok {
+				columnWithOrder = append(columnWithOrder, quote(column)+" "+order)
+			} else {
+				columnWithOrder = append(columnWithOrder, quote(column))
+			}
+		}
+		io.WriteString(w, strings.Join(columnWithOrder, ", "))
 		io.WriteString(w, ")")
 		if idx.invisible {
 			io.WriteString(w, " INVISIBLE")

--- a/maker_test.go
+++ b/maker_test.go
@@ -364,21 +364,6 @@ func (*Foo25) Indexes() []*Index {
 	}
 }
 
-type Foo26 struct {
-	ID  int32
-	Age int32
-}
-
-func (*Foo26) PrimaryKey() *PrimaryKey {
-	return NewPrimaryKey("id")
-}
-
-func (*Foo26) Indexes() []*Index {
-	return []*Index{
-		NewIndex("idx", "age").ASC("not_exist_column").DESC("not_exist_column"), // ignore order
-	}
-}
-
 type Foo27 struct {
 	ID  int32
 	Age int32
@@ -953,16 +938,6 @@ func TestMaker_Generate(t *testing.T) {
 		"    `id` INTEGER NOT NULL,\n"+
 		"    `age` INTEGER NOT NULL,\n"+
 		"    INDEX `idx` (`id` ASC, `age` DESC),\n"+
-		"    PRIMARY KEY (`id`)\n"+
-		") ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;\n\n"+
-		"SET foreign_key_checks=1;\n")
-
-	testMaker(t, []any{&Foo26{}}, "SET foreign_key_checks=0;\n\n"+
-		"DROP TABLE IF EXISTS `foo26`;\n\n"+
-		"CREATE TABLE `foo26` (\n"+
-		"    `id` INTEGER NOT NULL,\n"+
-		"    `age` INTEGER NOT NULL,\n"+
-		"    INDEX `idx` (`age`),\n"+
 		"    PRIMARY KEY (`id`)\n"+
 		") ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;\n\n"+
 		"SET foreign_key_checks=1;\n")

--- a/maker_test.go
+++ b/maker_test.go
@@ -349,6 +349,51 @@ func (*Foo23) PrimaryKey() *PrimaryKey {
 	return NewPrimaryKey("id")
 }
 
+type Foo25 struct {
+	ID  int32
+	Age int32
+}
+
+func (*Foo25) PrimaryKey() *PrimaryKey {
+	return NewPrimaryKey("id")
+}
+
+func (*Foo25) Indexes() []*Index {
+	return []*Index{
+		NewIndex("idx", "id", "age").ASC("id").DESC("age"),
+	}
+}
+
+type Foo26 struct {
+	ID  int32
+	Age int32
+}
+
+func (*Foo26) PrimaryKey() *PrimaryKey {
+	return NewPrimaryKey("id")
+}
+
+func (*Foo26) Indexes() []*Index {
+	return []*Index{
+		NewIndex("idx", "age").ASC("not_exist_column").DESC("not_exist_column"), // ignore order
+	}
+}
+
+type Foo27 struct {
+	ID  int32
+	Age int32
+}
+
+func (*Foo27) PrimaryKey() *PrimaryKey {
+	return NewPrimaryKey("id")
+}
+
+func (*Foo27) Indexes() []*Index {
+	return []*Index{
+		NewIndex("idx", "age").ASC("age").DESC("age"), // overwrite order
+	}
+}
+
 type Fkp1 struct {
 	ID string
 }
@@ -900,6 +945,36 @@ func TestMaker_Generate(t *testing.T) {
 		"    `id` INTEGER NOT NULL AUTO_INCREMENT,\n"+
 		"    PRIMARY KEY (`id`)\n"+
 		") COMMENT='test comment' ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;\n\n"+
+		"SET foreign_key_checks=1;\n")
+
+	testMaker(t, []any{&Foo25{}}, "SET foreign_key_checks=0;\n\n"+
+		"DROP TABLE IF EXISTS `foo25`;\n\n"+
+		"CREATE TABLE `foo25` (\n"+
+		"    `id` INTEGER NOT NULL,\n"+
+		"    `age` INTEGER NOT NULL,\n"+
+		"    INDEX `idx` (`id` ASC, `age` DESC),\n"+
+		"    PRIMARY KEY (`id`)\n"+
+		") ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;\n\n"+
+		"SET foreign_key_checks=1;\n")
+
+	testMaker(t, []any{&Foo26{}}, "SET foreign_key_checks=0;\n\n"+
+		"DROP TABLE IF EXISTS `foo26`;\n\n"+
+		"CREATE TABLE `foo26` (\n"+
+		"    `id` INTEGER NOT NULL,\n"+
+		"    `age` INTEGER NOT NULL,\n"+
+		"    INDEX `idx` (`age`),\n"+
+		"    PRIMARY KEY (`id`)\n"+
+		") ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;\n\n"+
+		"SET foreign_key_checks=1;\n")
+
+	testMaker(t, []any{&Foo27{}}, "SET foreign_key_checks=0;\n\n"+
+		"DROP TABLE IF EXISTS `foo27`;\n\n"+
+		"CREATE TABLE `foo27` (\n"+
+		"    `id` INTEGER NOT NULL,\n"+
+		"    `age` INTEGER NOT NULL,\n"+
+		"    INDEX `idx` (`age` DESC),\n"+
+		"    PRIMARY KEY (`id`)\n"+
+		") ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;\n\n"+
 		"SET foreign_key_checks=1;\n")
 
 	// nullable string foreign key


### PR DESCRIPTION
## Purpose

The myddlmaker supports MySQL descending INDEX. 
The Index structure now supports the `ASC()` method and `DESC()` method. Below is an example of how to use it. 

```golang
type Foo25 struct {
	ID  int32
	Age int32
}

func (*Foo25) PrimaryKey() *PrimaryKey {
	return NewPrimaryKey("id")
}

func (*Foo25) Indexes() []*Index {
	return []*Index{
		NewIndex("idx", "id", "age").ASC("id").DESC("age"),
	}
}
```

This PR maintains backward compatibility for DDL generation. If a column that does not exist in `ASC()` / `DESC()` is specified, the order specification will be ignored. If different orders are specified for the same column, the last specified order will take precedence. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced documentation with new examples for defining multi-column indexes.
  - Added support for specifying sort order (ascending/descending) in index definitions.
  - Introduced new structs (`Foo25`, `Foo27`) with composite and simple index definitions.

- **Bug Fixes**
  - Improved index generation logic to include column order in DDL outputs.

- **Tests**
  - Updated tests to validate the new index functionalities and ensure correct DDL generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->