### PR TITLE
add Go 1.23 to the build matrix

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,6 +22,7 @@ jobs:
           - "macos-latest"
           - "windows-latest"
         go:
+          - "1.23"
           - "1.22"
           - "1.21"
           - "1.20"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated CI workflow to include Go version "1.23" in the testing matrix, enhancing compatibility testing across multiple Go versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->