### PR TITLE
add MySQL 8.4 to the build matrix

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,6 +28,7 @@ jobs:
           - "1.19"
           - "1.18"
         mysql:
+          - "8.4"
           - "8.0"
     steps:
       - name: Check out code into the Go module directory


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced testing coverage by adding MySQL version "8.4" to the testing job matrix. 

- **Chores**
	- Updated workflow configuration for improved testing against multiple MySQL versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->