### PR TITLE
Support full-text indexes on multiple columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,9 @@ func (*User) FullTextIndexes() []*myddlmaker.FullTextIndex {
 
         // FULLTEXT INDEX `idx_name` (`name`) INVISIBLE
         myddlmaker.NewFullTextIndex("idx_name", "name").Invisible(),
+
+		// FULLTEXT INDEX `idx_name` (`name1`, `name2`)
+		myddlmaker.NewFullTextIndex("idx_name", "name1", "name2"),
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -367,8 +367,8 @@ func (*User) FullTextIndexes() []*myddlmaker.FullTextIndex {
         // FULLTEXT INDEX `idx_name` (`name`) INVISIBLE
         myddlmaker.NewFullTextIndex("idx_name", "name").Invisible(),
 
-		// FULLTEXT INDEX `idx_name` (`name1`, `name2`)
-		myddlmaker.NewFullTextIndex("idx_name", "name1", "name2"),
+        // FULLTEXT INDEX `idx_name` (`name1`, `name2`)
+        myddlmaker.NewFullTextIndex("idx_name", "name1", "name2"),
     }
 }
 ```

--- a/index.go
+++ b/index.go
@@ -241,23 +241,23 @@ type fullTextIndexes interface {
 //	}
 type FullTextIndex struct {
 	name      string
-	column    string
+	columns   []string
 	invisible bool
 	comment   string
 	parser    string
 }
 
 // NewFullTextIndex returns a new full text index.
-func NewFullTextIndex(name string, column string) *FullTextIndex {
+func NewFullTextIndex(name string, columns ...string) *FullTextIndex {
 	if name == "" {
 		panic("name is missing")
 	}
-	if column == "" {
-		panic("column is missing")
+	if len(columns) == 0 {
+		panic("columns is missing")
 	}
 	return &FullTextIndex{
-		name:   name,
-		column: column,
+		name:    name,
+		columns: columns,
 	}
 }
 

--- a/maker.go
+++ b/maker.go
@@ -259,7 +259,7 @@ func (m *Maker) generateIndex(w io.Writer, table *table) {
 		io.WriteString(w, "    FULLTEXT INDEX ")
 		io.WriteString(w, quote(idx.name))
 		io.WriteString(w, " (")
-		io.WriteString(w, quote(idx.column))
+		io.WriteString(w, strings.Join(quoteAll(idx.columns), ", "))
 		io.WriteString(w, ")")
 		if idx.invisible {
 			io.WriteString(w, " INVISIBLE")

--- a/maker_test.go
+++ b/maker_test.go
@@ -379,6 +379,22 @@ func (*Foo27) Indexes() []*Index {
 	}
 }
 
+type Foo28 struct {
+	ID      int32
+	Title   string
+	Content string
+}
+
+func (*Foo28) PrimaryKey() *PrimaryKey {
+	return NewPrimaryKey("id")
+}
+
+func (*Foo28) FullTextIndexes() []*FullTextIndex {
+	return []*FullTextIndex{
+		NewFullTextIndex("idx_title_content", "title", "content"),
+	}
+}
+
 type Fkp1 struct {
 	ID string
 }
@@ -948,6 +964,18 @@ func TestMaker_Generate(t *testing.T) {
 		"    `id` INTEGER NOT NULL,\n"+
 		"    `age` INTEGER NOT NULL,\n"+
 		"    INDEX `idx` (`age` DESC),\n"+
+		"    PRIMARY KEY (`id`)\n"+
+		") ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;\n\n"+
+		"SET foreign_key_checks=1;\n")
+
+	// FULLTEXT INDEX with multiple columns
+	testMaker(t, []any{&Foo28{}}, "SET foreign_key_checks=0;\n\n"+
+		"DROP TABLE IF EXISTS `foo28`;\n\n"+
+		"CREATE TABLE `foo28` (\n"+
+		"    `id` INTEGER NOT NULL,\n"+
+		"    `title` VARCHAR(191) NOT NULL,\n"+
+		"    `content` VARCHAR(191) NOT NULL,\n"+
+		"    FULLTEXT INDEX `idx_title_content` (`title`, `content`),\n"+
 		"    PRIMARY KEY (`id`)\n"+
 		") ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;\n\n"+
 		"SET foreign_key_checks=1;\n")


### PR DESCRIPTION
Previously, only single-column Full-Text Indexes were supported.

This change enables the creation of Full-Text Indexes on multiple columns.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for FULLTEXT indexes spanning multiple columns.

* **Documentation**
  * Extended README with examples of multi-column FULLTEXT index definitions.

* **Tests**
  * Added test coverage for multi-column FULLTEXT indexes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->