### PR TITLE
add Go 1.26 to the build matrix

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,7 +3,7 @@ name: Go
 on:
   push:
   pull_request:
-    branches: ["main"]
+    branches: [ "main" ]
 
 env:
   MYSQL_TEST_USER: gotest
@@ -22,6 +22,7 @@ jobs:
           - "macos-latest"
           - "windows-latest"
         go:
+          - "1.26"
           - "1.25"
           - "1.24"
           - "1.23"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Updated CI/CD test matrix to include Go version 1.26, extending testing coverage alongside existing Go versions (1.21-1.25)
* Updated workflow branch filter formatting for the main branch

<!-- end of auto-generated comment: release notes by coderabbit.ai -->